### PR TITLE
perf: use `Object.setPrototypeOf` firstly

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ function toFactory(Class) {
   const Factory = function(...args) {
     return new Class(...args)
   }
-  Factory.__proto__ = Class
+  Object.setPrototypeOf ? Object.setPrototypeOf(Factory, Class) : (Factory.__proto__ = Class)
   Factory.prototype = Class.prototype
   return Factory
 }


### PR DESCRIPTION
use `Object.setPrototypeOf` firstly, then fallback to `__proto__` in straightway

close #4